### PR TITLE
Replacing process.nextTick with setImmediate

### DIFF
--- a/lib/line_reader.js
+++ b/lib/line_reader.js
@@ -127,7 +127,7 @@
     open(filename, function(reader) {
       function newRead() {
         if (reader.hasNextLine()) {
-          process.nextTick(readNext);
+          setImmediate(readNext);
         } else {
           finish();
         }


### PR DESCRIPTION
This will solve Maximum call stack size exceeded error when dealing with large files.

When reading a large file with many lines, the maximum call stack size exceeded error occur. I was trying something like the following:

lineReader.eachLine('file.txt', function(line, last) {
...

}

(node) warning: Recursive process.nextTick detected. This will break in the next version of node. Please use setImmediate for recursive deferral.

RangeError: Maximum call stack size exceeded
