### PR TITLE
Close file handle when user wants to stop reading

### DIFF
--- a/lib/line_reader.js
+++ b/lib/line_reader.js
@@ -138,6 +138,7 @@
           newRead();
         } else {
           finish();
+          reader.close();
         }
       }
 
@@ -152,6 +153,7 @@
               newRead();
             } else {
               finish();
+              reader.close();
             }
           }
         });


### PR DESCRIPTION
The documentation states:

```
If the callback returns false, reading will stop and the file will be closed.
```
