### PR TITLE
support regexp separators and automatically handle windows/unix/mac properly by default

### DIFF
--- a/lib/line_reader.js
+++ b/lib/line_reader.js
@@ -7,14 +7,36 @@
   function LineReader(fd, cb, separator, encoding, bufferSize) {
     var filePosition   = 0,
         encoding       = encoding || 'utf8',
-        separator      = separator || '\n',
+        separator      = separator || /\r\n?|\n/,
         bufferSize     = bufferSize || 1024,
         buffer         = new Buffer(bufferSize),
         bufferStr      = '',
         decoder        = new StringDecoder(encoding),
         closed         = false,
         eof            = false,
-        separatorIndex = -1;
+        separatorIndex = -1,
+        separatorLen;
+
+    var findSeparator;
+
+    if (separator instanceof RegExp) {
+      findSeparator = function() {
+        var result = separator.exec(bufferStr);
+        if (result && (result.index + result[0].length < bufferStr.length || eof)) {
+          separatorIndex = result.index;
+          separatorLen = result[0].length;
+        }
+        else {
+          separatorIndex = -1;
+        }
+      }
+    }
+    else {
+      separatorLen = separator.length;
+      findSeparator = function() {
+        separatorIndex = bufferStr.indexOf(separator);
+      }
+    }
 
     function close() {
       if (!closed) {
@@ -30,8 +52,6 @@
     function readToSeparator(cb) {
       function readChunk() {
         fs.read(fd, buffer, 0, bufferSize, filePosition, function(err, bytesRead) {
-          var separatorAtEnd;
-
           if (err) {
             throw err;
           }
@@ -45,12 +65,9 @@
 
           bufferStr += decoder.write(buffer.slice(0, bytesRead));
 
-          if (separatorIndex < 0) {
-            separatorIndex = bufferStr.indexOf(separator);
-          }
+          findSeparator();
 
-          separatorAtEnd = separatorIndex === bufferStr.length - 1;
-          if (bytesRead && (separatorIndex === -1 || separatorAtEnd) && !eof) {
+          if (bytesRead && separatorIndex < 0 && !eof) {
             readChunk();
           } else {
             cb();
@@ -67,16 +84,17 @@
 
     function nextLine(cb) {
       function getLine() {
+        if (separatorIndex < 0 && eof) {
+          separatorIndex = bufferStr.length;
+        }
         var ret = bufferStr.substring(0, separatorIndex);
 
-        bufferStr = bufferStr.substring(separatorIndex + separator.length);
+        bufferStr = bufferStr.substring(separatorIndex + separatorLen);
         separatorIndex = -1;
         cb(ret);
       }
 
-      if (separatorIndex < 0) {
-        separatorIndex = bufferStr.indexOf(separator);
-      }
+      findSeparator();
 
       if (separatorIndex < 0) {
         if (eof) {

--- a/test/data/mac_os_9_file.txt
+++ b/test/data/mac_os_9_file.txt
@@ -1,0 +1,1 @@
+Jabberwocky’Twas brillig, and the slithy tovesDid gyre and gimble in the wabe;

--- a/test/data/unix_file.txt
+++ b/test/data/unix_file.txt
@@ -1,0 +1,6 @@
+Jabberwocky
+
+’Twas brillig, and the slithy toves
+Did gyre and gimble in the wabe;
+
+

--- a/test/data/windows_buffer_overlap_file.txt
+++ b/test/data/windows_buffer_overlap_file.txt
@@ -1,0 +1,2 @@
+test
+file

--- a/test/data/windows_file.txt
+++ b/test/data/windows_file.txt
@@ -1,0 +1,6 @@
+Jabberwocky
+
+’Twas brillig, and the slithy toves
+Did gyre and gimble in the wabe;
+
+

--- a/test/line_reader.js
+++ b/test/line_reader.js
@@ -1,13 +1,17 @@
-var lineReader             = require('../lib/line_reader'),
-    assert                 = require('assert'),
-    testFilePath           = __dirname + '/data/normal_file.txt',
-    separatorFilePath      = __dirname + '/data/separator_file.txt',
-    multiSeparatorFilePath = __dirname + '/data/multi_separator_file.txt',
-    multibyteFilePath      = __dirname + '/data/multibyte_file.txt',
-    emptyFilePath          = __dirname + '/data/empty_file.txt',
-    oneLineFilePath        = __dirname + '/data/one_line_file.txt',
-    threeLineFilePath      = __dirname + '/data/three_line_file.txt',
-    testSeparatorFile      = ['foo', 'bar\n', 'baz\n'],
+var lineReader                    = require('../lib/line_reader'),
+    assert                        = require('assert'),
+    testFilePath                  = __dirname + '/data/normal_file.txt',
+    windowsFilePath               = __dirname + '/data/windows_file.txt',
+    windowsBufferOverlapFilePath  = __dirname + '/data/windows_buffer_overlap_file.txt',
+    unixFilePath                  = __dirname + '/data/unix_file.txt',
+    macOs9FilePath                = __dirname + '/data/mac_os_9_file.txt',
+    separatorFilePath             = __dirname + '/data/separator_file.txt',
+    multiSeparatorFilePath        = __dirname + '/data/multi_separator_file.txt',
+    multibyteFilePath             = __dirname + '/data/multibyte_file.txt',
+    emptyFilePath                 = __dirname + '/data/empty_file.txt',
+    oneLineFilePath               = __dirname + '/data/one_line_file.txt',
+    threeLineFilePath             = __dirname + '/data/three_line_file.txt',
+    testSeparatorFile             = ['foo', 'bar\n', 'baz\n'],
     testFile = [
       'Jabberwocky',
       '',
@@ -15,6 +19,10 @@ var lineReader             = require('../lib/line_reader'),
       'Did gyre and gimble in the wabe;',
       '',
       ''
+    ],
+    testBufferOverlapFile = [
+      'test',
+      'file'
     ];
 
 describe("lineReader", function() {
@@ -23,6 +31,79 @@ describe("lineReader", function() {
       var i = 0;
 
       lineReader.eachLine(testFilePath, function(line, last) {
+        assert.equal(testFile[i], line, 'Each line should be what we expect');
+        i += 1;
+
+        if (i === 6) {
+          assert.ok(last);
+        } else {
+          assert.ok(!last);
+        }
+      }).then(function() {
+        assert.equal(6, i);
+        done();
+      });
+    });
+
+    it("should read windows files by default", function(done) {
+      var i = 0;
+
+      lineReader.eachLine(windowsFilePath, function(line, last) {
+        assert.equal(testFile[i], line, 'Each line should be what we expect');
+        i += 1;
+
+        if (i === 6) {
+          assert.ok(last);
+        } else {
+          assert.ok(!last);
+        }
+      }).then(function() {
+        assert.equal(6, i);
+        done();
+      });
+    });
+
+    it("should handle \\r\\n overlapping buffer window correctly", function(done) {
+      var i = 0;
+      var bufferSize = 5;
+
+      lineReader.eachLine(windowsBufferOverlapFilePath, function(line, last) {
+        assert.equal(testBufferOverlapFile[i], line, 'Each line should be what we expect');
+        i += 1;
+
+        if (i === 2) {
+          assert.ok(last);
+        } else {
+          assert.ok(!last);
+        }
+      }, undefined, undefined, bufferSize).then(function() {
+        assert.equal(2, i);
+        done();
+      });
+    });
+
+    it("should read unix files by default", function(done) {
+      var i = 0;
+
+      lineReader.eachLine(unixFilePath, function(line, last) {
+        assert.equal(testFile[i], line, 'Each line should be what we expect');
+        i += 1;
+
+        if (i === 6) {
+          assert.ok(last);
+        } else {
+          assert.ok(!last);
+        }
+      }).then(function() {
+        assert.equal(6, i);
+        done();
+      });
+    });
+
+    it("should read mac os 9 files by default", function(done) {
+      var i = 0;
+
+      lineReader.eachLine(macOs9FilePath, function(line, last) {
         assert.equal(testFile[i], line, 'Each line should be what we expect');
         i += 1;
 


### PR DESCRIPTION
This change makes the default separator `/\r\n?|\n/`, so that it automatically handles windows, mac, or unix files properly.  It still supports string separators as well.  If the regexp match is at the very end of the string, it will try to read more so in case there is a longer match.

I added tests for windows, mac, and unix files, and also a test where the buffer boundary falls in the middle of an `\r\n` (it should still parse as a single line break with the default settings).

This also fixes https://github.com/nickewing/line-reader/issues/24 by adding this check to the beginning of `getLine()`:
```
    function nextLine(cb) {
      function getLine() {
        if (separatorIndex < 0 && eof) {
          separatorIndex = bufferStr.length;
        }
```

Cheers!
Andy