### PR TITLE
convert to node-style callbacks and options hashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,20 @@ by returning `false` from the iteratee):
       console.log("I'm done!!");
     });
 
+If you want to use promises, `eachLine` and `open` are compatible with `promisify`
+from [bluebird](https://github.com/petkaantonov/bluebird/blob/master/API.md#promisepromisifyfunction-nodefunction--dynamic-receiver---function):
+
+    var lineReader = require('line-reader'),
+        Promise = require('bluebird');
+
+    var eachLine = Promise.promisify(lineReader.eachLine);
+    eachLine('file.txt', function(line) {
+      console.log(line);
+    }).then(function() {
+      console.log('done');
+    }).catch(function(err) {
+      console.error(err);
+    });
 
 For more granular control, `open`, `hasNextLine`, and `nextLine` maybe be used
 to iterate a file (but you must `close` it yourself):

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Promises
       console.error(err);
     });
 
-If you're using a promise library that doesn't have a promisify function, it's still easy:
+If you're using a promise library that doesn't have a promisify function, here's how you can do it:
 
     var lineReader = require('line-reader'),
         Promise = require(...);

--- a/README.md
+++ b/README.md
@@ -57,20 +57,31 @@ by returning `false` from the iteratee):
 
 
 For more granular control, `open`, `hasNextLine`, and `nextLine` maybe be used
-to iterate a file:
+to iterate a file (but you must `close` it yourself):
 
     // or read line by line:
     lineReader.open('file.txt', function(err, reader) {
       if (err) throw err;
       if (reader.hasNextLine()) {
         reader.nextLine(function(err, line) {
-          if (err) throw err;
-          console.log(line);
+          try {
+            if (err) throw err;
+            console.log(line);
+          } finally {
+            reader.close(function(err) {
+              if (err) throw err;          
+            });
+          }
+        });
+      }
+      else {
+        reader.close(function(err) {
+          if (err) throw err;          
         });
       }
     });
 
-You may provide additional options before the callbacks:
+You may provide additional options in a hash before the callbacks to `eachLine` or `open`:
 * `separator`   - a `string` or `RegExp` separator (defaults to `/\r\n?|\n/`)
 * `encoding`    - file encoding (defaults to `'utf8'`)
 * `bufferSize`  - amount of bytes to buffer (defaults to 1024)
@@ -80,7 +91,9 @@ For example:
     lineReader.eachLine('file.txt', {separator: ';', encoding: 'utf8'}, function(line, last, cb) {
       console.log(line);
     });
-
+    lineReader.open('file.txt', {bufferSize: 1024}, function(err, reader) {
+      ...
+    }); 
 
 Contributors
 ------------

--- a/README.md
+++ b/README.md
@@ -71,9 +71,16 @@ to iterate a file:
     });
 
 You may provide additional options before the callbacks:
-* separator   - a string or RegExp separator (defaults to `/\r\n?|\n/`)
-* encoding    - file encoding (defaults to `'utf8'`)
-* bufferSize  - amount of bytes to buffer (defaults to 1024)
+* `separator`   - a `string` or `RegExp` separator (defaults to `/\r\n?|\n/`)
+* `encoding`    - file encoding (defaults to `'utf8'`)
+* `bufferSize`  - amount of bytes to buffer (defaults to 1024)
+
+For example:
+
+    lineReader.eachLine('file.txt', {separator: ';', encoding: 'utf8'}, function(line, last, cb) {
+      console.log(line);
+    });
+
 
 Contributors
 ------------

--- a/README.md
+++ b/README.md
@@ -41,15 +41,17 @@ callback parameter like so:
       }
     });
 
-The `eachLine` function also returns an object with one property, `then`.  If a
-callback is provided to `then`, it will be called once all lines have been read.
+You can provide an optional second node-style callback that will be called with
+`(err)` on failure or `()` when finished (even if you manually terminate iteration
+by returning `false` from the iteratee):
 
     var lineReader = require('line-reader');
 
     // read all lines:
     lineReader.eachLine('file.txt', function(line) {
       console.log(line);
-    }).then(function () {
+    }).then(function (err) {
+      if (err) throw err;
       console.log("I'm done!!");
     });
 
@@ -58,13 +60,20 @@ For more granular control, `open`, `hasNextLine`, and `nextLine` maybe be used
 to iterate a file:
 
     // or read line by line:
-    lineReader.open('file.txt', function(reader) {
+    lineReader.open('file.txt', function(err, reader) {
+      if (err) throw err;
       if (reader.hasNextLine()) {
-        reader.nextLine(function(line) {
+        reader.nextLine(function(err, line) {
+          if (err) throw err;
           console.log(line);
         });
       }
     });
+
+You may provide additional options before the callbacks:
+* separator   - a string or RegExp separator (defaults to `/\r\n?|\n/`)
+* encoding    - file encoding (defaults to `'utf8'`)
+* bufferSize  - amount of bytes to buffer (defaults to 1024)
 
 Contributors
 ------------

--- a/README.md
+++ b/README.md
@@ -55,21 +55,6 @@ by returning `false` from the iteratee):
       console.log("I'm done!!");
     });
 
-If you want to use promises, `eachLine` and `open` are compatible with `promisify`
-from [bluebird](https://github.com/petkaantonov/bluebird/blob/master/API.md#promisepromisifyfunction-nodefunction--dynamic-receiver---function):
-
-    var lineReader = require('line-reader'),
-        Promise = require('bluebird');
-
-    var eachLine = Promise.promisify(lineReader.eachLine);
-    eachLine('file.txt', function(line) {
-      console.log(line);
-    }).then(function() {
-      console.log('done');
-    }).catch(function(err) {
-      console.error(err);
-    });
-
 For more granular control, `open`, `hasNextLine`, and `nextLine` maybe be used
 to iterate a file (but you must `close` it yourself):
 
@@ -108,6 +93,47 @@ For example:
     lineReader.open('file.txt', {bufferSize: 1024}, function(err, reader) {
       ...
     }); 
+
+Promises
+--------
+
+`eachLine` and `open` are compatible with `promisify` from [bluebird](https://github.com/petkaantonov/bluebird/blob/master/API.md#promisepromisifyfunction-nodefunction--dynamic-receiver---function):
+
+    var lineReader = require('line-reader'),
+        Promise = require('bluebird');
+
+    var eachLine = Promise.promisify(lineReader.eachLine);
+    eachLine('file.txt', function(line) {
+      console.log(line);
+    }).then(function() {
+      console.log('done');
+    }).catch(function(err) {
+      console.error(err);
+    });
+
+If you're using a promise library that doesn't have a promisify function, it's still easy:
+
+    var lineReader = require('line-reader'),
+        Promise = require(...);
+
+    var eachLine = function(filename, options, iteratee) {
+      return new Promise(function(resolve, reject) {
+        lineReader.eachLine(filename, options, iteratee, function(err) {
+          if (err) {
+            reject(err);
+          } else {
+            resolve();
+          }
+        });
+      });
+    }
+    eachLine('file.txt', function(line) {
+      console.log(line);
+    }).then(function() {
+      console.log('done');
+    }).catch(function(err) {
+      console.error(err);
+    });
 
 Contributors
 ------------

--- a/lib/line_reader.js
+++ b/lib/line_reader.js
@@ -4,11 +4,17 @@
   var fs = require('fs'),
       StringDecoder = require('string_decoder').StringDecoder;
 
-  function LineReader(fd, cb, separator, encoding, bufferSize) {
+  function createLineReader(fd, options, cb) {
+    if (options instanceof Function) {
+      cb = options;
+      options = undefined;
+    }
+    if (!options) options = {};
+
     var filePosition   = 0,
-        encoding       = encoding || 'utf8',
-        separator      = separator || /\r\n?|\n/,
-        bufferSize     = bufferSize || 1024,
+        encoding       = options.encoding || 'utf8',
+        separator      = options.separator || /\r\n?|\n/,
+        bufferSize     = options.bufferSize || 1024,
         buffer         = new Buffer(bufferSize),
         bufferStr      = '',
         decoder        = new StringDecoder(encoding),
@@ -38,13 +44,9 @@
       }
     }
 
-    function close() {
+    function close(cb) {
       if (!closed) {
-        fs.close(fd, function(err) {
-          if (err) {
-            throw err;
-          }
-        });
+        fs.close(fd, cb);
         closed = true;
       }
     }
@@ -53,12 +55,11 @@
       function readChunk() {
         fs.read(fd, buffer, 0, bufferSize, filePosition, function(err, bytesRead) {
           if (err) {
-            throw err;
+            return cb(err);
           }
 
           if (bytesRead < bufferSize) {
             eof = true;
-            close();
           }
 
           filePosition += bytesRead;
@@ -83,7 +84,15 @@
     }
 
     function nextLine(cb) {
-      function getLine() {
+      if (closed) {
+        return cb(new Error('LineReader has been closed'));
+      }
+
+      function getLine(err) {
+        if (err) {
+          return cb(err);
+        }
+
         if (separatorIndex < 0 && eof) {
           separatorIndex = bufferStr.length;
         }
@@ -91,7 +100,7 @@
 
         bufferStr = bufferStr.substring(separatorIndex + separatorLen);
         separatorIndex = -1;
-        cb(ret);
+        cb(undefined, ret);
       }
 
       findSeparator();
@@ -102,7 +111,7 @@
             separatorIndex = bufferStr.length;
             getLine();
           } else {
-            throw new Error('No more lines to read.');
+            return cb(new Error('No more lines to read.'));
           }
         } else {
           readToSeparator(getLine);
@@ -112,37 +121,53 @@
       }
     }
 
-    this.hasNextLine = hasNextLine;
-    this.nextLine = nextLine;
-    this.close = close;
-
-    readToSeparator(cb);
-  }
-
-  function open(filename, cb, separator, encoding, bufferSize) {
-    fs.open(filename, 'r', parseInt('666', 8), function(err, fd) {
-      var reader;
+    readToSeparator(function(err) {
       if (err) {
-        throw err;
+        return cb(err);
       }
-
-      reader = new LineReader(fd, function() {
-        cb(reader);
-      }, separator, encoding, bufferSize);
+      return cb(undefined, {
+        hasNextLine:  hasNextLine,
+        nextLine:     nextLine,
+        close:        close
+      });
     });
   }
 
-  function eachLine(filename, cb, separator, encoding, bufferSize) {
-    var finalFn,
-        asyncCb = cb.length == 3;
-
-    function finish() {
-      if (finalFn && typeof finalFn === 'function') {
-        finalFn();
-      }
+  function open(filename, options, cb) {
+    if (options instanceof Function) {
+      cb = options;
+      options = undefined;
     }
 
-    open(filename, function(reader) {
+    fs.open(filename, 'r', parseInt('666', 8), function(err, fd) {
+      if (err) {
+        return cb(err);
+      }
+
+      createLineReader(fd, options, cb);
+    });
+  }
+
+  function eachLine(filename, options, iteratee, cb) {
+    if (options instanceof Function) {
+      cb = iteratee;
+      iteratee = options;
+      options = undefined;
+    }
+    var finalFn,
+        asyncIteratee = iteratee.length == 3;
+
+    open(filename, options, function(err, reader) {
+      if (err) {
+        return cb(err);
+      }
+
+      function finish(err) {
+        reader.close(function(err2) {
+          cb(err || err2); 
+        });
+      }
+
       function newRead() {
         if (reader.hasNextLine()) {
           setImmediate(readNext);
@@ -156,35 +181,31 @@
           newRead();
         } else {
           finish();
-          reader.close();
         }
       }
 
       function readNext() {
-        reader.nextLine(function(line) {
+        reader.nextLine(function(err, line) {
+          if (err) {
+            finish(err);
+          }
+
           var last = !reader.hasNextLine();
 
-          if (asyncCb) {
-            cb(line, last, continueCb);
+          if (asyncIteratee) {
+            iteratee(line, last, continueCb);
           } else {
-            if (cb(line, last) !== false) {
+            if (iteratee(line, last) !== false) {
               newRead();
             } else {
               finish();
-              reader.close();
             }
           }
         });
       }
 
       newRead();
-    }, separator, encoding, bufferSize);
-
-    return {
-      then: function(cb) {
-        finalFn = cb;
-      }
-    };
+    });
   }
 
   module.exports.open = open;

--- a/lib/line_reader.js
+++ b/lib/line_reader.js
@@ -184,13 +184,13 @@
       }
 
       if (err) {
-        if (cb) cb(err, reader);
+        if (cb) cb(err);
         return;
       }
 
       function finish(err) {
         reader.close(function(err2) {
-          if (cb) cb(err || err2, reader); 
+          if (cb) cb(err || err2); 
         });
       }
 

--- a/lib/line_reader.js
+++ b/lib/line_reader.js
@@ -44,6 +44,10 @@
       }
     }
 
+    function _fd() {
+      return fd;
+    }
+
     function close(cb) {
       if (!closed) {
         fs.close(fd, cb);
@@ -141,6 +145,7 @@
         close:        close,
         isOpen:       isOpen,
         isClosed:     isClosed,
+        fd:           _fd,
       });
     });
   }
@@ -169,7 +174,15 @@
     var finalFn,
         asyncIteratee = iteratee.length == 3;
 
+    var theReader;
+    var getReaderCb;
+
     open(filename, options, function(err, reader) {
+      theReader = reader;
+      if (getReaderCb) {
+        getReaderCb(reader);
+      }
+
       if (err) {
         if (cb) cb(err, reader);
         return;
@@ -219,6 +232,20 @@
 
       newRead();
     });
+
+    // this hook is only for the sake of testing; if you choose to use it,
+    // please don't file any issues (unless you can also reproduce them without 
+    // using this).
+    return {
+      getReader: function(cb) {
+        if (theReader) {
+          cb(theReader);
+        }
+        else {
+          getReaderCb = cb;
+        }
+      }
+    };
   }
 
   module.exports.open = open;

--- a/lib/line_reader.js
+++ b/lib/line_reader.js
@@ -31,13 +31,11 @@
         if (result && (result.index + result[0].length < bufferStr.length || eof)) {
           separatorIndex = result.index;
           separatorLen = result[0].length;
-        }
-        else {
+        } else {
           separatorIndex = -1;
         }
       }
-    }
-    else {
+    } else {
       separatorLen = separator.length;
       findSeparator = function() {
         separatorIndex = bufferStr.indexOf(separator);
@@ -240,8 +238,7 @@
       getReader: function(cb) {
         if (theReader) {
           cb(theReader);
-        }
-        else {
+        } else {
           getReaderCb = cb;
         }
       }

--- a/lib/line_reader.js
+++ b/lib/line_reader.js
@@ -123,7 +123,9 @@
 
     readToSeparator(function(err) {
       if (err) {
-        return cb(err);
+        return close(function(err2) {
+          return cb(err || err2);
+        });
       }
       return cb(undefined, {
         hasNextLine:  hasNextLine,

--- a/lib/line_reader.js
+++ b/lib/line_reader.js
@@ -158,13 +158,14 @@
         asyncIteratee = iteratee.length == 3;
 
     open(filename, options, function(err, reader) {
-      if (err) {
-        return cb(err);
+      if (err ) {
+        if (cb) cb(err);
+        return;
       }
 
       function finish(err) {
         reader.close(function(err2) {
-          cb(err || err2); 
+          if (cb) cb(err || err2); 
         });
       }
 

--- a/lib/line_reader.js
+++ b/lib/line_reader.js
@@ -51,6 +51,14 @@
       }
     }
 
+    function isOpen() {
+      return !closed;
+    }
+
+    function isClosed() {
+      return closed;
+    }
+
     function readToSeparator(cb) {
       function readChunk() {
         fs.read(fd, buffer, 0, bufferSize, filePosition, function(err, bytesRead) {
@@ -130,7 +138,9 @@
       return cb(undefined, {
         hasNextLine:  hasNextLine,
         nextLine:     nextLine,
-        close:        close
+        close:        close,
+        isOpen:       isOpen,
+        isClosed:     isClosed,
       });
     });
   }
@@ -160,14 +170,14 @@
         asyncIteratee = iteratee.length == 3;
 
     open(filename, options, function(err, reader) {
-      if (err ) {
-        if (cb) cb(err);
+      if (err) {
+        if (cb) cb(err, reader);
         return;
       }
 
       function finish(err) {
         reader.close(function(err2) {
-          if (cb) cb(err || err2); 
+          if (cb) cb(err || err2, reader); 
         });
       }
 

--- a/test/line_reader.js
+++ b/test/line_reader.js
@@ -261,19 +261,22 @@ describe("lineReader", function() {
     });
 
     it("should close the file when eachLine finishes", function(done) {
+      var reader;
       lineReader.eachLine(oneLineFilePath, function(line, last) {
         return false;
-      }, function(err, reader) {
+      }, function(err) {
         assert.ok(!err);
         assert.ok(reader.isClosed());
         done();
+      }).getReader(function(_reader) {
+        reader = _reader;
       });
     });
 
     it("should close the file if there is an error during eachLine", function(done) {
       var reader;
       lineReader.eachLine(testFilePath, {bufferSize: 10}, function(line, last) {
-      }, function(err, reader) {
+      }, function(err) {
         delete readErrorFds[reader.fd()];
         assert.ok(err);
         assert.ok(reader.isClosed());

--- a/test/line_reader.js
+++ b/test/line_reader.js
@@ -224,6 +224,19 @@ describe("lineReader", function() {
       });
     });
 
+    it("should error when the user tries calls nextLine on a closed LineReader", function(done) {
+      lineReader.open(oneLineFilePath, function(err, reader) {
+        assert.ok(!err);
+        reader.close(function(err) {
+          assert.ok(!err);
+          reader.nextLine(function(err, line) {
+            assert.ok(err, "nextLine should have errored because the reader is closed");
+            done();
+          });
+        });
+      });
+    });
+
     it("should work with a file containing only one line", function(done) {
       lineReader.eachLine(oneLineFilePath, function(line, last) {
         return true;
@@ -233,6 +246,15 @@ describe("lineReader", function() {
       });
     });
 
+    it("should close the file when eachLine finishes", function(done) {
+      lineReader.eachLine(oneLineFilePath, function(line, last) {
+        return false;
+      }, function(err, reader) {
+        assert.ok(!err);
+        assert.ok(reader.isClosed());
+        done();
+      });
+    });
   });
 
   describe("open", function() {

--- a/test/line_reader.js
+++ b/test/line_reader.js
@@ -39,7 +39,8 @@ describe("lineReader", function() {
         } else {
           assert.ok(!last);
         }
-      }).then(function() {
+      }, function(err) {
+        assert.ok(!err);
         assert.equal(6, i);
         done();
       });
@@ -57,7 +58,8 @@ describe("lineReader", function() {
         } else {
           assert.ok(!last);
         }
-      }).then(function() {
+      }, function(err) {
+        assert.ok(!err);
         assert.equal(6, i);
         done();
       });
@@ -67,7 +69,7 @@ describe("lineReader", function() {
       var i = 0;
       var bufferSize = 5;
 
-      lineReader.eachLine(windowsBufferOverlapFilePath, function(line, last) {
+      lineReader.eachLine(windowsBufferOverlapFilePath, {bufferSize: bufferSize}, function(line, last) {
         assert.equal(testBufferOverlapFile[i], line, 'Each line should be what we expect');
         i += 1;
 
@@ -76,7 +78,8 @@ describe("lineReader", function() {
         } else {
           assert.ok(!last);
         }
-      }, undefined, undefined, bufferSize).then(function() {
+      }, function(err) {
+        assert.ok(!err);
         assert.equal(2, i);
         done();
       });
@@ -94,7 +97,8 @@ describe("lineReader", function() {
         } else {
           assert.ok(!last);
         }
-      }).then(function() {
+      }, function(err) {
+        assert.ok(!err);
         assert.equal(6, i);
         done();
       });
@@ -112,7 +116,8 @@ describe("lineReader", function() {
         } else {
           assert.ok(!last);
         }
-      }).then(function() {
+      }, function(err) {
+        assert.ok(!err);
         assert.equal(6, i);
         done();
       });
@@ -132,7 +137,8 @@ describe("lineReader", function() {
         }
 
         process.nextTick(cb);
-      }).then(function() {
+      }, function(err) {
+        assert.ok(!err);
         assert.equal(6, i);
         done();
       });
@@ -140,7 +146,7 @@ describe("lineReader", function() {
 
     it("should separate files using given separator", function(done) {
       var i = 0;
-      lineReader.eachLine(separatorFilePath, function(line, last) {
+      lineReader.eachLine(separatorFilePath, {separator: ';'}, function(line, last) {
         assert.equal(testSeparatorFile[i], line);
         i += 1;
       
@@ -149,7 +155,8 @@ describe("lineReader", function() {
         } else {
           assert.ok(!last);
         }
-      }, ';').then(function() {
+      }, function(err) {
+        assert.ok(!err);
         assert.equal(3, i);
         done();
       });
@@ -157,7 +164,7 @@ describe("lineReader", function() {
 
     it("should separate files using given separator with more than one character", function(done) {
       var i = 0;
-      lineReader.eachLine(multiSeparatorFilePath, function(line, last) {
+      lineReader.eachLine(multiSeparatorFilePath, {separator: '||'}, function(line, last) {
         assert.equal(testSeparatorFile[i], line);
         i += 1;
       
@@ -166,7 +173,8 @@ describe("lineReader", function() {
         } else {
           assert.ok(!last);
         }
-      }, '||').then(function() {
+      }, function(err) {
+        assert.ok(!err);
         assert.equal(3, i);
         done();
       });
@@ -181,7 +189,8 @@ describe("lineReader", function() {
         if (i === 2) {
           return false;
         }
-      }).then(function() {
+      }, function(err) {
+        assert.ok(!err);
         assert.equal(2, i);
         done();
       });
@@ -199,7 +208,8 @@ describe("lineReader", function() {
           cb();
         }
 
-      }).then(function() {
+      }, function(err) {
+        assert.ok(!err);
         assert.equal(2, i);
         done();
       });
@@ -208,15 +218,18 @@ describe("lineReader", function() {
     it("should not call callback on empty file", function(done) {
       lineReader.eachLine(emptyFilePath, function(line) {
         assert.ok(false, "Empty file should not cause any callbacks");
-      }).then(function() {
+      }, function(err) {
+        assert.ok(!err);
         done()
       });
     });
 
     it("should work with a file containing only one line", function(done) {
       lineReader.eachLine(oneLineFilePath, function(line, last) {
+        return true;
+      }, function(err) {
+        assert.ok(!err);
         done();
-        return false;
       });
     });
 
@@ -224,36 +237,40 @@ describe("lineReader", function() {
 
   describe("open", function() {
     it("should return a reader object and allow calls to nextLine", function(done) {
-      lineReader.open(testFilePath, function(reader) {
+      lineReader.open(testFilePath, function(err, reader) {
+        assert.ok(!err);
         assert.ok(reader.hasNextLine());
       
         assert.ok(reader.hasNextLine(), 'Calling hasNextLine multiple times should be ok');
       
-        reader.nextLine(function(line) {
+        reader.nextLine(function(err, line) {
+          assert.ok(!err);
           assert.equal('Jabberwocky', line);
           assert.ok(reader.hasNextLine());
-          reader.nextLine(function(line) {
+          reader.nextLine(function(err, line) {
+            assert.ok(!err);
             assert.equal('', line);
             assert.ok(reader.hasNextLine());
-            reader.nextLine(function(line) {
+            reader.nextLine(function(err, line) {
+              assert.ok(!err);
               assert.equal('’Twas brillig, and the slithy toves', line);
               assert.ok(reader.hasNextLine());
-              reader.nextLine(function(line) {
+              reader.nextLine(function(err, line) {
+                assert.ok(!err);
                 assert.equal('Did gyre and gimble in the wabe;', line);
                 assert.ok(reader.hasNextLine());
-                reader.nextLine(function(line) {
+                reader.nextLine(function(err, line) {
+                  assert.ok(!err);
                   assert.equal('', line);
                   assert.ok(reader.hasNextLine());
-                  reader.nextLine(function(line) {
+                  reader.nextLine(function(err, line) {
+                    assert.ok(!err);
                     assert.equal('', line);
                     assert.ok(!reader.hasNextLine());
-      
-                    assert.throws(function() {
-                      reader.nextLine(function() {
-                      });
-                    }, Error, "Should be able to read next line at EOF");
-
-                    done();
+                    reader.nextLine(function(err, line) {
+                      assert.ok(err);
+                      done();
+                    });
                   });
                 });
               });
@@ -264,39 +281,55 @@ describe("lineReader", function() {
     });
 
     it("should work with a file containing only one line", function(done) {
-      lineReader.open(oneLineFilePath, function(reader) {
-        done();
+      lineReader.open(oneLineFilePath, function(err, reader) {
+        assert.ok(!err);
+        reader.close(function(err) {
+          assert.ok(!err);
+          done();
+        });
       });
     });
 
     it("should read multibyte characters on the buffer boundary", function(done) {
-      lineReader.open(multibyteFilePath, function(reader) {
+      lineReader.open(multibyteFilePath, {separator: '\n', encoding: 'utf8', bufferSize: 2}, function(err, reader) {
+        assert.ok(!err);
         assert.ok(reader.hasNextLine());
-        reader.nextLine(function(line) {
+        reader.nextLine(function(err, line) {
+          assert.ok(!err);
           assert.equal('ふうりうの初やおくの田植うた', line,
                        "Should read multibyte characters on buffer boundary");
-          done();
+          reader.close(function(err) {
+            assert.ok(!err);
+            done();
+          });
         });
-      }, '\n', 'utf8', 2);
+      });
     });
 
     describe("hasNextLine", function() {
       it("should return true when buffer is empty but not at EOF", function(done) {
-        lineReader.open(threeLineFilePath, function(reader) {
-          reader.nextLine(function(line) {
+        lineReader.open(threeLineFilePath, {separator: '\n', encoding: 'utf8', bufferSize: 36}, function(err, reader) {
+          assert.ok(!err);
+          reader.nextLine(function(err, line) {
+            assert.ok(!err);
             assert.equal("This is line one.", line);
             assert.ok(reader.hasNextLine());
-            reader.nextLine(function(line) {
+            reader.nextLine(function(err, line) {
+              assert.ok(!err);
               assert.equal("This is line two.", line);
               assert.ok(reader.hasNextLine());
-              reader.nextLine(function(line) {
+              reader.nextLine(function(err, line) {
+                assert.ok(!err);
                 assert.equal("This is line three.", line);
                 assert.ok(!reader.hasNextLine());
-                done();
+                reader.close(function(err) {
+                  assert.ok(!err);
+                  done();
+                })
               });
             });
           });
-        }, '\n', 'utf-8', 36);
+        });
       });
     });
   });


### PR DESCRIPTION
With this all callbacks except for the iteratee of `eachLine` take the arguments `(err, result)`.  `eachLine` accepts an optional second callback of this form that's called upon error or when it finishes reading lines.  I got rid of the `.then()` handler -- instead we should recommend using [promisify from bluebird](https://github.com/petkaantonov/bluebird/blob/master/API.md#promisepromisifyfunction-nodefunction--dynamic-receiver---function) or something like it.

Also, I moved the options into a hash argument (like [fs.readFile](https://nodejs.org/api/fs.html#fs_fs_readfile_filename_options_callback)).  This is obviously a breaking change, so the major version should be bumped if you merge this PR.

Note: I haven't added any tests for what happens when the FS errors out in the middle of reading a file.  Do you have any idea how to simulate that?

This should take care of the following issues:
* https://github.com/nickewing/line-reader/issues/23
* https://github.com/nickewing/line-reader/issues/20
* https://github.com/nickewing/line-reader/issues/16
* https://github.com/nickewing/line-reader/issues/11 (this PR changes the specification: the final callback will get called whether or not the line iteratee returns `false`)
* https://github.com/nickewing/line-reader/issues/10
* https://github.com/nickewing/line-reader/issues/7